### PR TITLE
Ensure GTK2 application are themed

### DIFF
--- a/session
+++ b/session
@@ -6,4 +6,6 @@ set -e
 # we don't really on readlink -f "$0", as we always want to
 # point to current/ to get latest update applied immediately.
 XDG_DATA_DIRS=$XDG_DATA_DIRS:/snap/communitheme/current/share/
+GTK2_RC_FILES=$GTK2_RC_FILES:/snap/communitheme/current/share/themes/Communitheme/gtk-2.0/gtkrc
+export GTK2_RC_FILES
 gnome-session --session=ubuntu


### PR DESCRIPTION
GTK2 doesn't respect XDG_DATA_DIRS for loading gtkrc files. Instead of
distro-patching it, there is the alternative to use GTK2_RC_FILES env variable
to point directly the toolkit to a specific file.