### PR TITLE
Enable releasing as well gtk-common-themes with latest communitheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,5 +25,7 @@ By default, you track manually tested and curated releases of communitheme snap.
 and published to the snap store when any project related to communitheme has changed (being GNOME Shell theme, or icon or…).
 
 For switching to it, you can switch to the **edge** channel, by running: `snap refresh communitheme --edge`.
+If you want to follow the **edge** content for snap applications, you will need as well to switch `gtk-common-theme` snap
+to the same channel: `snap refresh gtk-common-themes --edge`.
 
 If you haven't install the snap yet but want to directly track the edge channel, you can run `snap install communitheme --edge`.

--- a/build/gtk-common-themes-parts.yaml
+++ b/build/gtk-common-themes-parts.yaml
@@ -1,0 +1,28 @@
+parts:
+  communitheme:
+    plugin: nil
+    build-packages: [snapd]
+    # note: at this date (13/04/18), build-snaps gives a segfault in docker image
+    build: |
+      set -eu
+      snap download communitheme --channel=CHANNEL
+      unsquashfs communitheme*.snap
+    install: |
+      set -eu
+      cp -a squashfs-root/share $SNAPCRAFT_PART_INSTALL/
+      rm -rf $SNAPCRAFT_PART_INSTALL/share/gnome-shell/
+  # everything else but communitheme
+  gtk-common-themes-others:
+    plugin: nil
+    build-packages: [snapd]
+    build: |
+      set -eu
+      snap download gtk-common-themes --edge
+      unsquashfs gtk-common-themes*.snap
+    install: |
+      set -eu
+      [ -d squashfs-root/ ] || exit 1
+      cp -a squashfs-root/* $SNAPCRAFT_PART_INSTALL/
+      # remove everything related to communitheme
+      rm -rf $SNAPCRAFT_PART_INSTALL/share/*/*ommunitheme
+      rm -rf $SNAPCRAFT_PART_INSTALL/share/icons/Sury

--- a/build/prepare-build-snap
+++ b/build/prepare-build-snap
@@ -35,8 +35,30 @@ fi
 
 docker run -v $(pwd):$(pwd) -t snapcore/snapcraft sh -c "$cmd"
 
+# stop if this was just a test build without any snap pushed
+[ -z "$channel" ] && exit 0
+
+# build now gtk-common-themes
+# FIXME: we won't need this once snapd can accept and auto-install theme snaps.
+mkdir -p ../gtk-common-themes/snap
+cd ../gtk-common-themes
+
+# get top part of original snapcraft.yaml and complete with unsquash the snap
+gct_snapcraftyaml=`mktemp`
+curl -o $gct_snapcraftyaml "https://raw.githubusercontent.com/snapcrafters/gtk-common-themes/master/snap/snapcraft.yaml"
+sed -e '/parts:/,$d' $gct_snapcraftyaml > snap/snapcraft.yaml
+
+curl -o $gct_snapcraftyaml "$THEME_HELPER_REPO_URL/build/gtk-common-themes-parts.yaml"
+sed -e "s,CHANNEL,$channel,g" $gct_snapcraftyaml >> snap/snapcraft.yaml
+rm $gct_snapcraftyaml
+
+# build and push gtk-common-themes snap
+cmd="cd $(pwd) && snapcraft"
+cmd="$cmd && echo \"$SNAP_COMMON_THEMES_TOKEN\" | snapcraft login --with - && snapcraft push *.snap --release=$channel"
+docker run -v $(pwd):$(pwd) -t snapcore/snapcraft sh -c "$cmd"
+
 # write on PR install instructions for the snap branch
 [ "$TRAVIS_PULL_REQUEST" == "false" ] && exit 0
 curl -H "Authorization: token ${GITHUB_TOKEN}" -X POST \
-        -d "{\"body\": \"A new test snap version is available using: \`snap refresh communitheme --channel=$channel\`.\nFurther available updates will track that pull request then.\n\nSwitch back to stable or edge snap with \`snap refresh communitheme --stable\` or \`snap refresh communitheme --edge\` once you are done with it!\n\nReplace \`refresh\` with \`install\` if you haven't installed the snap yet.\"}" \
+        -d "{\"body\": \"A new test snap version is available using: \`snap refresh communitheme --channel=$channel\`.\nFurther available updates will track that pull request then.\n\nSwitch back to stable or edge snap with \`snap refresh communitheme --stable\` or \`snap refresh communitheme --edge\` once you are done with it!\nYou may want to download as well \`gtk-common-themes\` snap from \`$channel\` channel to test your snaps with those changes.\n\nReplace \`refresh\` with \`install\` if you haven't installed the snap yet.\"}" \
         "https://api.github.com/repos/${TRAVIS_REPO_SLUG}/issues/${TRAVIS_PULL_REQUEST}/comments"

--- a/session
+++ b/session
@@ -6,4 +6,6 @@ set -e
 # we don't really on readlink -f "$0", as we always want to
 # point to current/ to get latest update applied immediately.
 XDG_DATA_DIRS=$XDG_DATA_DIRS:/snap/communitheme/current/share/
+GTK2_RC_FILES=$GTK2_RC_FILES:/snap/communitheme/current/share/themes/Communitheme/gtk-2.0/gtkrc
+export GTK2_RC_FILES
 gnome-session --session=ubuntu

--- a/session
+++ b/session
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+# script_file=`readlink -f "$0"`
+# `dirname "$script_file"`/share/
+# we don't really on readlink -f "$0", as we always want to
+# point to current/ to get latest update applied immediately.
+XDG_DATA_DIRS=$XDG_DATA_DIRS:/snap/communitheme/current/share/
+gnome-session --session=ubuntu


### PR DESCRIPTION
We don't rebuild gtk-common-themes as we only want to rebuild it with latest
communitheme snap content that we extract.
Always download the preambule of gtk-common-themes and then, download
from the edge channel its content, stripping communitheme one.
Then, ensure we download communitheme from the current channel and push that
to the store.